### PR TITLE
Add codecov configuration

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,17 +1,5 @@
-coverage:
-  status:
-    project:
-      default:
-        # Allow coverage to drop by up to 5% before failing CI
-        threshold: 5%
-        informational: true # report only, do not fail CI
-    patch:
-      default:
-        # Do not fail CI on patch coverage drops
-        informational: true
-
 ignore:
-  # Exclude UI code for now - requires TestFX for JavaFX automated testing (possibly in the future)
+  # Exclude UI code - requires TestFX for JavaFX automated testing
   - "src/main/java/seedu/address/ui"
-  # Exclude seed data utility
+  # Exclude seed data utility - no testable logic
   - "src/main/java/seedu/address/model/util/SampleDataUtil.java"


### PR DESCRIPTION
## Summary
Added codecov configuration so that:
1. Continues to flag for code outside ignore list
2. Ignores the `ui` package and `SampleDataUtil.java` from coverage reporting as they are not covered by automated tests.