### PR TITLE
Handle duplicate prefixes in add and delete

### DIFF
--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -24,7 +24,6 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public DeleteCommand parse(String args) throws ParseException {
-        // TODO: bug fix -- handle duplicate prefixes
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
 
@@ -32,6 +31,8 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
         }
+
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS);
 
         try {
             PersonInformation info = new PersonInformationParser().parse(argMultimap);

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -24,7 +24,6 @@ public class FindCommandParser implements Parser<FindCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public FindCommand parse(String args) throws ParseException {
-        // TODO: bug fix -- handle duplicate prefixes
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
 
@@ -32,6 +31,7 @@ public class FindCommandParser implements Parser<FindCommand> {
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS);
         try {
             PersonInformation info = new PersonInformationParser().parse(argMultimap);
             return new FindCommand(info);

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -1,13 +1,17 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.logic.Messages;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.PersonInformation;
@@ -46,5 +50,27 @@ public class DeleteCommandParserTest {
     public void parse_invalidPhone_throwsParseException() {
         assertParseFailure(parser, " " + PREFIX_NAME + "John Doe " + PREFIX_PHONE + "abc",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_repeatedNonTagValue_failure() {
+        String validExpectedPersonString = " " + PREFIX_NAME + "John Doe"
+                + " " + PREFIX_PHONE + "98765432"
+                + " " + PREFIX_EMAIL + "john@example.com"
+                + " " + PREFIX_ADDRESS + "Block 123, NUS Street 1"
+                + " " + PREFIX_TAG + "CS2103";
+
+        // multiple names
+        assertParseFailure(parser, " " + PREFIX_NAME + "Jane Doe" + validExpectedPersonString,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME));
+
+        // multiple fields repeated
+        assertParseFailure(parser,
+                validExpectedPersonString
+                        + " " + PREFIX_PHONE + "91234567"
+                        + " " + PREFIX_EMAIL + "john2@example.com"
+                        + " " + PREFIX_NAME + "John2"
+                        + " " + PREFIX_ADDRESS + "Block 456, NUS Street 2",
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME, PREFIX_ADDRESS, PREFIX_EMAIL, PREFIX_PHONE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -13,6 +13,7 @@ import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.logic.Messages;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
@@ -41,6 +42,28 @@ public class FindCommandParserTest {
     public void parse_invalidOptionalField_throwsParseException() {
         assertParseFailure(parser, " " + PREFIX_NAME + "Alex Tan " + PREFIX_PHONE + "not-a-phone",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_repeatedNonTagValue_failure() {
+        String validExpectedPersonString = " " + PREFIX_NAME + "Alex Tan"
+                + " " + PREFIX_PHONE + "98765432"
+                + " " + PREFIX_EMAIL + "alex@example.com"
+                + " " + PREFIX_ADDRESS + "Block 123, NUS Street 1"
+                + " " + PREFIX_TAG + "CS2103";
+
+        // multiple names
+        assertParseFailure(parser, " " + PREFIX_NAME + "Alice" + validExpectedPersonString,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME));
+
+        // multiple fields repeated
+        assertParseFailure(parser,
+                validExpectedPersonString
+                        + " " + PREFIX_PHONE + "91234567"
+                        + " " + PREFIX_EMAIL + "alex2@example.com"
+                        + " " + PREFIX_NAME + "Alex2"
+                        + " " + PREFIX_ADDRESS + "Block 456, NUS Street 2",
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME, PREFIX_ADDRESS, PREFIX_EMAIL, PREFIX_PHONE));
     }
 
     @Test


### PR DESCRIPTION
Close #95 
## Description
1. Added duplicate prefix detection for the `add` and `delete` commands.
2. Inputs containing duplicate prefixes are now rejected, and error message is shown to inform user.