### PR TITLE
Refactor CSV import/export to dual-file format (persons/events)

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ExportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExportCommand.java
@@ -7,7 +7,9 @@ import static seedu.address.logic.parser.ExportCommandParser.PREFIX_TYPE;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import seedu.address.commons.util.FileUtil;
@@ -17,18 +19,20 @@ import seedu.address.model.event.Event;
 import seedu.address.model.person.Person;
 
 /**
- * Exports a list of contacts into a CSV formatted file for future use.
+ * Exports a list of contacts into two separate CSV formatted files for future use:
+ * - {filename}_persons.csv containing contact information with event ID references
+ * - {filename}_events.csv containing all unique events
  */
 public class ExportCommand extends Command {
 
     public static final String COMMAND_WORD = "export";
 
-    public static final String MESSAGE_SUCCESS = "Exported list to %1$s";
+    public static final String MESSAGE_SUCCESS = "Exported list to %1$s_persons.csv and %1$s_events.csv";
 
     public static final String MESSAGE_FAILURE = "Failed to export list to %1$s";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Exports a list of contacts into a CSV formatted file for future use.\n"
+            + ": Exports a list of contacts into two CSV formatted files for future use.\n"
             + "Parameters: "
             + PREFIX_TYPE + "EXPORT_TYPE "
             + PREFIX_FILENAME + "FILENAME\n"
@@ -37,14 +41,25 @@ public class ExportCommand extends Command {
             + PREFIX_FILENAME + "myContacts";
 
     private static final String FILENAME_SUFFIX = ".csv";
+    private static final String PERSONS_FILENAME_SUFFIX = "_persons.csv";
+    private static final String EVENTS_FILENAME_SUFFIX = "_events.csv";
+
+    // Person CSV headers
     private static final String NAME_COLUMN_HEADER = "Name";
     private static final String PHONE_COLUMN_HEADER = "Phone";
     private static final String EMAIL_COLUMN_HEADER = "Email";
     private static final String ADDRESS_COLUMN_HEADER = "Address";
     private static final String TAG_COLUMN_HEADER = "Tags";
-    private static final String EVENT_COLUMN_HEADER = "Events";
+    private static final String EVENT_IDS_COLUMN_HEADER = "EventIds";
     private static final String PHOTO_COLUMN_HEADER = "Photo";
     private static final String PINNED_COLUMN_HEADER = "Pinned";
+
+    // Event CSV headers
+    private static final String EVENT_ID_COLUMN_HEADER = "EventId";
+    private static final String TITLE_COLUMN_HEADER = "Title";
+    private static final String DESCRIPTION_COLUMN_HEADER = "Description";
+    private static final String START_TIME_COLUMN_HEADER = "Start";
+    private static final String END_TIME_COLUMN_HEADER = "End";
 
     private final String exportType;
     private final String filename;
@@ -64,7 +79,8 @@ public class ExportCommand extends Command {
 
     /**
      * Executes the export command, retrieving the appropriate list of contacts based on
-     * the {@code exportType} and writing them to a CSV file at the determined path.
+     * the {@code exportType} and writing them to two CSV files:
+     * one for persons and one for events.
      *
      * @param model {@code Model} which the command should operate on.
      * @return A {@code CommandResult} indicating the success of the export operation.
@@ -76,44 +92,65 @@ public class ExportCommand extends Command {
 
         List<Person> exportedList = getExportedList(model);
 
-        Path exportPath = getExportPath(model);
+        // Collect all unique events referenced by exported persons
+        Set<Event> uniqueEvents = collectUniqueEvents(exportedList);
 
-        exportDataToCsv(exportPath, exportedList, model);
+        Path personsExportPath = getPersonsExportPath(model);
+        Path eventsExportPath = getEventsExportPath(model);
 
-        return new CommandResult(String.format(MESSAGE_SUCCESS,
-                filename + FILENAME_SUFFIX));
+        exportDataToTwoCsv(personsExportPath, eventsExportPath, exportedList, uniqueEvents, model);
+
+        return new CommandResult(String.format(MESSAGE_SUCCESS, filename));
     }
 
     /**
-     * Writes the specified list of contacts to a CSV file. Creates parent directories if
-     * they do not exist and converts the {@code Person} data into a formatted CSV string.
+     * Writes the specified lists of contacts and events to two separate CSV files.
+     * Creates parent directories if they do not exist.
      *
-     * @param exportPath The {@code Path} where the file will be saved.
+     * @param personsPath The {@code Path} where the persons file will be saved.
+     * @param eventsPath The {@code Path} where the events file will be saved.
      * @param exportedList The list of {@code Person} objects to be serialized.
+     * @param uniqueEvents The set of {@code Event} objects to be serialized.
      * @throws CommandException If an {@code IOException} occurs during file creation or writing.
      */
-    public void exportDataToCsv(Path exportPath, List<Person> exportedList, Model model) throws CommandException {
+    public void exportDataToTwoCsv(Path personsPath, Path eventsPath, List<Person> exportedList,
+                                   Set<Event> uniqueEvents, Model model) throws CommandException {
         try {
-            FileUtil.createParentDirsOfFile(exportPath);
+            FileUtil.createParentDirsOfFile(personsPath);
+            FileUtil.createParentDirsOfFile(eventsPath);
 
-            String csvData = convertToCsv(exportedList, model);
+            String personsCsvData = convertPersonsToCsv(exportedList, model);
+            String eventsCsvData = convertEventsToCsv(uniqueEvents);
 
-            FileUtil.writeToFile(exportPath, csvData);
+            FileUtil.writeToFile(personsPath, personsCsvData);
+            FileUtil.writeToFile(eventsPath, eventsCsvData);
         } catch (IOException e) {
-            throw new CommandException(String.format(MESSAGE_FAILURE, filename + FILENAME_SUFFIX));
+            throw new CommandException(String.format(MESSAGE_FAILURE, filename));
         }
     }
 
     /**
-     * Returns the path to the CSV file to be exported, resolved relative to the
+     * Returns the path to the persons CSV file to be exported, resolved relative to the
      * directory containing the current AddressBook data file.
      *
      * @param model {@code Model} providing the base file path from user preferences.
-     * @return The resolved {@code Path} for the export file.
+     * @return The resolved {@code Path} for the persons export file.
      */
-    protected Path getExportPath(Model model) {
+    protected Path getPersonsExportPath(Model model) {
         Path userPrefParentDirPath = model.getAddressBookFilePath().getParent();
-        return userPrefParentDirPath.resolve(filename + FILENAME_SUFFIX);
+        return userPrefParentDirPath.resolve(filename + PERSONS_FILENAME_SUFFIX);
+    }
+
+    /**
+     * Returns the path to the events CSV file to be exported, resolved relative to the
+     * directory containing the current AddressBook data file.
+     *
+     * @param model {@code Model} providing the base file path from user preferences.
+     * @return The resolved {@code Path} for the events export file.
+     */
+    protected Path getEventsExportPath(Model model) {
+        Path userPrefParentDirPath = model.getAddressBookFilePath().getParent();
+        return userPrefParentDirPath.resolve(filename + EVENTS_FILENAME_SUFFIX);
     }
 
     /**
@@ -130,13 +167,14 @@ public class ExportCommand extends Command {
     }
 
     /**
-     * Converts the specified list of contacts into a single CSV string, including
-     * a header row followed by individual data rows for each person.
+     * Converts the specified list of contacts into a CSV string for persons,
+     * including a header row followed by individual data rows for each person.
+     * Each person row contains references to event IDs instead of full event data.
      *
      * @param exportedList The list of {@code Person} objects to convert.
-     * @return A formatted CSV string representing the entire contact list.
+     * @return A formatted CSV string representing the persons list.
      */
-    public String convertToCsv(List<Person> exportedList, Model model) {
+    public String convertPersonsToCsv(List<Person> exportedList, Model model) {
         StringBuilder csvBuilder = new StringBuilder();
 
         csvBuilder.append(NAME_COLUMN_HEADER).append(",")
@@ -144,7 +182,7 @@ public class ExportCommand extends Command {
                 .append(EMAIL_COLUMN_HEADER).append(",")
                 .append(ADDRESS_COLUMN_HEADER).append(",")
                 .append(TAG_COLUMN_HEADER).append(",")
-                .append(EVENT_COLUMN_HEADER).append(",")
+                .append(EVENT_IDS_COLUMN_HEADER).append(",")
                 .append(PHOTO_COLUMN_HEADER).append(",")
                 .append(PINNED_COLUMN_HEADER).append("\n");
 
@@ -156,8 +194,31 @@ public class ExportCommand extends Command {
     }
 
     /**
-     * Formats an individual {@code Person} into a single CSV row, ensuring that
-     * complex fields like addresses and tags are sanitized to prevent formatting errors.
+     * Converts the specified set of events into a CSV string,
+     * including a header row followed by individual data rows for each event.
+     *
+     * @param uniqueEvents The set of {@code Event} objects to convert.
+     * @return A formatted CSV string representing the events list.
+     */
+    public String convertEventsToCsv(Set<Event> uniqueEvents) {
+        StringBuilder csvBuilder = new StringBuilder();
+
+        csvBuilder.append(EVENT_ID_COLUMN_HEADER).append(",")
+                .append(TITLE_COLUMN_HEADER).append(",")
+                .append(DESCRIPTION_COLUMN_HEADER).append(",")
+                .append(START_TIME_COLUMN_HEADER).append(",")
+                .append(END_TIME_COLUMN_HEADER).append("\n");
+
+        for (Event e : uniqueEvents) {
+            csvBuilder.append(formatEventToRow(e)).append("\n");
+        }
+
+        return csvBuilder.toString();
+    }
+
+    /**
+     * Formats an individual {@code Person} into a single CSV row, with event references
+     * as comma-separated event IDs instead of full event data.
      *
      * @param p The {@code Person} object to format.
      * @return A comma-separated string representing the person's data.
@@ -169,7 +230,7 @@ public class ExportCommand extends Command {
                 sanitizeAndWrapValue(getEmailValue(p)),
                 sanitizeAndWrapValue(getAddressValue(p)),
                 sanitizeAndWrapValue(formatTags(p)),
-                sanitizeAndWrapValue(formatEvents(p)),
+                sanitizeAndWrapValue(formatEventIds(p)),
                 sanitizeAndWrapValue(getPhotoValue()),
                 sanitizeAndWrapValue(String.valueOf(model.isPersonPinned(p)))
         );
@@ -212,40 +273,50 @@ public class ExportCommand extends Command {
     }
 
     /**
-     * Formats a single {@code Event} into a pipe-separated string.
-     * Special characters like pipe and semicolon are removed from the description
-     * to maintain CSV integrity.
+     * Formats a single {@code Event} into a CSV row.
+     * Special characters like pipe and semicolon are removed to maintain CSV integrity.
      *
      * @param e The {@code Event} object to format.
-     * @return A pipe-separated string of event details.
+     * @return A comma-separated string of event details.
      */
-    // Event column becomes: Title|Description|Start|End|NumberOfPersonLinked|EventId
-    private String formatSingleEvent(Event e) {
-        String title = e.getTitle().fullTitle; // adjust if getter differs
+    private String formatEventToRow(Event e) {
+        String title = e.getTitle().fullTitle;
         String desc = e.getDescription().map(d -> d.fullDescription).orElse("");
-        String sanitizedTitle = title.replace("|", " ").replace(";", " ");
-        String sanitizedDesc = desc.replace("|", " ").replace(";", " ");
+        String sanitizedTitle = title.replace(",", " ").replace("\"", " ");
+        String sanitizedDesc = desc.replace(",", " ").replace("\"", " ");
 
-        return String.format("%s|%s|%s|%s|%d|%d",
-                sanitizedTitle,
-                sanitizedDesc,
-                e.getStartTimeFormatted(), // or timeRange.getStartTimeFormatted()
-                e.getEndTimeFormatted(),
-                e.getNumberOfPersonLinked(),
-                e.getEventId());
+        return String.format("%d,%s,%s,%s,%s",
+                e.getEventId(),
+                sanitizeAndWrapValue(sanitizedTitle),
+                sanitizeAndWrapValue(sanitizedDesc),
+                e.getStartTimeFormatted(),
+                e.getEndTimeFormatted());
     }
 
     /**
-     * Aggregates all events associated with a {@code Person} into a single string,
-     * with individual events separated by semicolons.
+     * Formats a person's event IDs as a semicolon-separated string.
      *
      * @param p The {@code Person} object containing events.
-     * @return A semicolon-separated string of formatted events.
+     * @return A semicolon-separated string of event IDs.
      */
-    private String formatEvents(Person p) {
+    private String formatEventIds(Person p) {
         return p.getEvents().stream()
-                .map(this::formatSingleEvent)
+                .map(event -> String.valueOf(event.getEventId()))
                 .collect(Collectors.joining(";"));
+    }
+
+    /**
+     * Collects all unique events referenced by the exported persons.
+     *
+     * @param exportedList The list of persons to extract events from.
+     * @return A set of unique {@code Event} objects.
+     */
+    private Set<Event> collectUniqueEvents(List<Person> exportedList) {
+        Set<Event> uniqueEvents = new HashSet<>();
+        for (Person person : exportedList) {
+            uniqueEvents.addAll(person.getEvents());
+        }
+        return uniqueEvents;
     }
 
     /**
@@ -286,6 +357,6 @@ public class ExportCommand extends Command {
      */
     @Override
     public String toString() {
-        return String.format("Exporting list to: %s", filename + FILENAME_SUFFIX);
+        return String.format("Exporting list to: %s", filename);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ImportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ImportCommand.java
@@ -56,12 +56,11 @@ public class ImportCommand extends Command {
             + PREFIX_TYPE + "add "
             + PREFIX_FILENAME + "myContacts";
 
-    public static final String MESSAGE_SUCCESS = "Successfully imported list from %1$s";
     public static final String MESSAGE_INVALID_COLUMNS_CSV = "Number of columns in CSV file "
             + " do not match the expected format.";
     public static final String MESSAGE_ERROR_READING_FILE = "Error reading data from %1$s";
     public static final String MESSAGE_EMPTY_FILE = "The file %1$s is empty.";
-    public static final String MESSAGE_SUCCESS_ROWS_ADDED_SKIPPED = "Successfully imported list from %1$s with "
+    public static final String MESSAGE_SUCCESS_ROWS_ADDED_SKIPPED = "Successfully imported list from %1$s.csv with "
             + "%2$d row(s) added, %3$d row(s) skipped.";
 
     private static final Logger logger = LogsCenter.getLogger(ImportCommand.class);
@@ -83,22 +82,26 @@ public class ImportCommand extends Command {
     }
 
     /**
-     * Executes the import command, reading data from the specified CSV file and
-     * updating the model's address book.
+     * Executes the import command, reading data from two separate CSV files:
+     * {filename}_events.csv and {filename}_persons.csv, and updating the model's address book.
      *
      * @param model {@code Model} which the command should operate on.
      * @return A {@code CommandResult} containing the summary of added and skipped rows.
-     * @throws CommandException If the file cannot be read, is malformed, or contains invalid data.
+     * @throws CommandException If the files cannot be read, are malformed, or contain invalid data.
      */
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        Path importPath = getImportPath(model);
-        List<String> allLines = readLinesFromCsv(importPath);
+        Path eventsPath = getEventsImportPath(model);
+        Path personsPath = getPersonsImportPath(model);
 
-        if (hasHeaderOnly(allLines)) {
-            return new CommandResult(String.format(MESSAGE_EMPTY_FILE, filename + FILENAME_SUFFIX));
+        List<String> eventsLines = readLinesFromCsv(eventsPath);
+        List<String> personLines = readLinesFromCsv(personsPath);
+
+
+        if (hasHeaderOnly(personLines)) {
+            return new CommandResult(String.format(MESSAGE_EMPTY_FILE, filename + "_persons.csv"));
         }
 
         AddressBook tempAddressBook;
@@ -110,14 +113,16 @@ public class ImportCommand extends Command {
         }
         tempModel.setAddressBook(tempAddressBook);
 
-        int addedRows = processImportedLinesFromCsv(tempModel, allLines);
-        int totalRows = allLines.size() - 1;
+        Map<Integer, Event> eventMap = new HashMap<>();
+        processImportedEventsFromCsv(tempModel, eventsLines, eventMap);
+        int addedRows = processImportedPersonsFromCsv(tempModel, personLines, eventMap);
+        int totalRows = personLines.size() - 1;
         int skippedRows = totalRows - addedRows;
 
         // Reaches here if successful, copies over what was performed to the current model
         model.setAddressBook(tempModel.getAddressBook());
         return new CommandResult(String.format(MESSAGE_SUCCESS_ROWS_ADDED_SKIPPED,
-                filename + FILENAME_SUFFIX,
+                filename,
                 addedRows,
                 skippedRows));
     }
@@ -132,13 +137,13 @@ public class ImportCommand extends Command {
         try {
             List<String> lines = Files.readAllLines(importPath, StandardCharsets.UTF_8);
             if (lines.isEmpty()) {
-                throw new CommandException(String.format(MESSAGE_EMPTY_FILE, filename + FILENAME_SUFFIX));
+                throw new CommandException(String.format(MESSAGE_EMPTY_FILE, importPath.getFileName().toString()));
             }
             return lines;
 
         } catch (IOException e) {
             throw new CommandException(String.format(MESSAGE_ERROR_READING_FILE,
-                    filename + FILENAME_SUFFIX));
+                    importPath.getFileName().toString()));
         }
     }
 
@@ -152,41 +157,53 @@ public class ImportCommand extends Command {
     }
 
     /**
-     * Parses all data rows of the CSV into {@code Person} objects, registers their
-     * events with the global model, then adds each person if they do not already exist.
-     * @param model The {@code Model} to be updated with new contacts and events.
-     * @param lines The list of all lines (including header) from the CSV.
-     * @return The count of successfully added rows.
-     * @throws CommandException If an error is encountered while parsing or adding a {@code Person}.
+     * Parses all event rows from the events CSV and registers them with the model.
+     * Events are added to the provided eventMap for reference by persons.
+     *
+     * @param model The {@code Model} to register events with.
+     * @param lines The list of all lines (including header) from the events CSV.
+     * @param eventMap The map to store parsed events by their event IDs.
      */
-    private int processImportedLinesFromCsv(Model model, List<String> lines) throws CommandException {
-        int added = 0;
-        Map<Integer, Event> eventMap = new HashMap<>();
-
-        // Pass 1: parse all rows. Events are collected into eventMap.
-        List<ParsedPerson> parsedPersons = new ArrayList<>();
+    private void processImportedEventsFromCsv(Model model, List<String> lines, Map<Integer, Event> eventMap) {
         for (int i = 1; i < lines.size(); i++) {
-            Optional<ParsedPerson> person = parseLineToPerson(lines.get(i), eventMap);
-            person.ifPresent(parsedPersons::add);
-        }
-
-        // Pass 2: register every unique parsed event with the global model.
-        for (Event event : eventMap.values()) {
-            if (!model.hasEvent(event) && !model.hasOverlappingEvent(event)) {
-                model.addEvent(event);
+            try {
+                Optional<ParsedEvent> event = parseLineToEvent(lines.get(i));
+                if (event.isPresent()) {
+                    ParsedEvent parsedEvent = event.get();
+                    eventMap.put(parsedEvent.eventId, parsedEvent.event);
+                    if (!model.hasEvent(parsedEvent.event) && !model.hasOverlappingEvent(parsedEvent.event)) {
+                        model.addEvent(parsedEvent.event);
+                    }
+                }
+            } catch (IllegalArgumentException e) {
+                logger.info(String.format("ImportCommand: Skipping malformed event entry: %s", lines.get(i)));
             }
         }
+    }
 
-        // Pass 3: add persons. Their internal event lists already reference the
-        // same objects registered globally in pass 2.
-        for (ParsedPerson parsedPerson : parsedPersons) {
-            Person person = parsedPerson.person;
-            if (!model.hasPerson(person)) {
-                model.addPerson(person);
-                if (parsedPerson.isPinned) {
-                    model.pinPerson(person);
+    /**
+     * Parses all person rows from the persons CSV, linking them to events via event IDs.
+     *
+     * @param model The {@code Model} to be updated with new contacts.
+     * @param lines The list of all lines (including header) from the persons CSV.
+     * @param eventMap The map of available events indexed by event ID.
+     * @return The count of successfully added rows.
+     */
+    private int processImportedPersonsFromCsv(Model model, List<String> lines, Map<Integer, Event> eventMap) {
+        int added = 0;
+
+        for (int i = 1; i < lines.size(); i++) {
+            Optional<ParsedPerson> person = parseLineToPerson(lines.get(i), eventMap);
+            if (person.isPresent()) {
+                ParsedPerson parsedPerson = person.get();
+                Person p = parsedPerson.person;
+                if (!model.hasPerson(p)) {
+                    model.addPerson(p);
+                    if (parsedPerson.isPinned) {
+                        model.pinPerson(p);
+                    }
+                    added++;
                 }
-                added++;
             }
         }
 
@@ -198,7 +215,8 @@ public class ImportCommand extends Command {
     /**
      * Attempts to parse a CSV line into a {@code Person} object.
      * Captures parsing errors to allow the import process to continue with other rows.
-     * @param line A single data row from the CSV file.
+     * @param line A single data row from the persons CSV file.
+     * @param eventMap Map of event IDs to Event objects for linking.
      * @return An {@code Optional} containing the {@code Person} if parsing was successful,
      *         otherwise an empty {@code Optional}.
      */
@@ -206,44 +224,106 @@ public class ImportCommand extends Command {
         try {
             return Optional.of(createPersonFromCsvRow(line, eventMap));
         } catch (IllegalArgumentException e) {
+            String error = e.getMessage();
+            logger.info(String.format("ImportCommand: Skipping invalid person entry: %s. Reason: %s", line, error));
             return Optional.empty();
         }
     }
 
     /**
-     * Helps convert a raw CSV row into a {@code Person} object by
-     * splitting the line, validating the structure, and populating contact and event data.
+     * Attempts to parse a CSV line into an {@code Event} object.
+     * @param line A single data row from the events CSV file.
+     * @return An {@code Optional} containing the {@code Event} if parsing was successful,
+     *         otherwise an empty {@code Optional}.
+     */
+    Optional<ParsedEvent> parseLineToEvent(String line) {
+        // Blank event rows are treated as empty entries.
+        if (line == null || line.trim().isEmpty()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(createEventFromCsvRow(line));
+    }
+
+    /**
+     * Helps convert a raw CSV row from the events file into an {@code Event} object.
      *
-     * @param row A single comma-separated string from the CSV file.
+     * @param row A single comma-separated string from the events CSV file.
+     * @return An {@code Event} object populated with the data from the row.
+     */
+    ParsedEvent createEventFromCsvRow(String row) {
+        String[] columns = CsvUtil.splitCsvLine(row);
+        if (columns.length < 5) {
+            throw new IllegalArgumentException("Event row does not have required columns");
+        }
+
+        try {
+            int eventId = Integer.parseInt(columns[0].trim());
+            String titleStr = unwrapValue(columns[1]).trim();
+            String descStr = unwrapValue(columns[2]).trim();
+            String startStr = columns[3].trim();
+            String endStr = columns[4].trim();
+
+            if (titleStr.isEmpty() || startStr.isEmpty() || endStr.isEmpty()) {
+                throw new IllegalArgumentException("Event has missing required fields");
+            }
+
+            Title title = new Title(titleStr);
+            Optional<Description> desc = descStr.isEmpty()
+                    ? Optional.empty()
+                    : Optional.of(new Description(descStr));
+            TimeRange timeRange = new TimeRange(startStr, endStr);
+
+            return new ParsedEvent(eventId, new Event(title, desc, timeRange));
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Event ID must be a valid integer");
+        }
+    }
+
+    /**
+     * Helps convert a raw CSV row from the persons file into a {@code Person} object by
+     * splitting the line, validating the structure, and populating contact and event data.
+     * Events are linked via event IDs from the provided eventMap.
+     *
+     * @param row A single comma-separated string from the persons CSV file.
+     * @param eventMap Map of event IDs to Event objects for linking.
      * @return A {@code Person} object populated with the data from the row.
      */
     private ParsedPerson createPersonFromCsvRow(String row, Map<Integer, Event> eventMap) {
         String[] columns = CsvUtil.splitCsvLine(row);
-        validateColumnCount(columns);
+        validatePersonColumnCount(columns);
 
         Person person = populatePersonInfo(columns);
         populateEventInfo(person, unwrapValue(columns[5]), eventMap);
 
-        boolean isPinned = columns.length >= 8 && Boolean.parseBoolean(unwrapValue(columns[7]));
+        boolean isPinned = parsePinnedValue(columns);
 
         return new ParsedPerson(person, isPinned);
     }
 
     /**
-     * Validates that the split CSV row contains at least the minimum number of required columns.
+     * Validates that the split CSV row from the persons file contains the required columns.
      *
      * @param columns An array of strings representing the split CSV fields.
-     * @throws IllegalArgumentException If the column count is less than the expected format (6).
+     * @throws IllegalArgumentException If the column count is less than expected (8).
      */
-    private void validateColumnCount(String[] columns) {
-        if (columns.length < 7) {
+    private void validatePersonColumnCount(String[] columns) {
+        if (columns.length < 8) {
             throw new IllegalArgumentException(MESSAGE_INVALID_COLUMNS_CSV);
         }
     }
 
     /**
-     * Extracts and initializes the {@code Person} fields except Events (Name, Phone, Email, Address, Tags)
+     * Parses pinned value from supported person CSV schema variants.
+     */
+    private boolean parsePinnedValue(String[] columns) {
+        return Boolean.parseBoolean(unwrapValue(columns[7]));
+    }
+
+    /**
+     * Extracts and initializes the {@code Person} fields except Events (Name, Phone, Email, Address, Tags, Photo)
      * from the split CSV columns to create a new {@code Person} instance.
+     * Events are not populated here; they are linked separately via event IDs.
      *
      * @param columns An array of strings containing the split CSV fields.
      * @return A {@code Person} object initialized with the extracted information.
@@ -267,14 +347,52 @@ public class ImportCommand extends Command {
     }
 
     /**
-     * Parses the CSV event string into a list of {@code Event} objects and
-     * associates them with the specified {@code Person}.
+     * Parses the CSV event ID string (semicolon-separated event IDs) and
+     * links the corresponding events to the specified {@code Person}.
+     *
      * @param p The {@code Person} object to receive the events.
-     * @param eventString The raw, semicolon-separated event string from the CSV.
+     * @param eventIdString The raw, semicolon-separated event ID string from the CSV.
+     * @param eventMap Map of event IDs to Event objects for linking.
      */
-    private void populateEventInfo(Person p, String eventString, Map<Integer, Event> eventMap) {
-        List<Event> events = parseEvents(eventString, eventMap);
+    private void populateEventInfo(Person p, String eventIdString, Map<Integer, Event> eventMap) {
+        List<Event> events = parseEventIds(eventIdString, eventMap);
         events.forEach(p::addEvent);
+    }
+
+    /**
+     * Parses a semicolon-separated string of event IDs and retrieves the corresponding
+     * Event objects from the eventMap.
+     *
+     * @param eventIdString The raw string containing event IDs (e.g., "101;102;103").
+     * @param eventMap Map of event IDs to Event objects.
+     * @return A {@code List} of {@code Event} objects.
+     *         Returns an empty list if input is empty or if event IDs are not found.
+     */
+    List<Event> parseEventIds(String eventIdString, Map<Integer, Event> eventMap) {
+        List<Event> events = new ArrayList<>();
+
+        if (eventIdString == null || eventIdString.trim().isEmpty()) {
+            return events;
+        }
+
+        String[] eventIds = eventIdString.split(";");
+        for (String idStr : eventIds) {
+            try {
+                int eventId = Integer.parseInt(idStr.trim());
+                Event event = eventMap.get(eventId);
+                if (event != null) {
+                    events.add(event);
+                } else {
+                    logger.info(String.format(
+                            "ImportCommand: Event with ID %d not found in events map", eventId));
+                }
+            } catch (NumberFormatException e) {
+                logger.info(String.format(
+                        "ImportCommand: Invalid event ID format in persons CSV: %s", idStr));
+            }
+        }
+
+        return events;
     }
 
     /**
@@ -291,15 +409,40 @@ public class ImportCommand extends Command {
     }
 
     /**
-     * Returns the path to the CSV file to be imported, resolved relative to the
+     * Helper container for an imported event and its CSV EventId.
+     */
+    static class ParsedEvent {
+        private final int eventId;
+        private final Event event;
+
+        ParsedEvent(int eventId, Event event) {
+            this.eventId = eventId;
+            this.event = event;
+        }
+    }
+
+    /**
+     * Returns the path to the events CSV file to be imported, resolved relative to the
      * directory containing the current AddressBook data file.
      *
      * @param model {@code Model} used to get the base file path from user preferences.
-     * @return The resolved {@code Path} pointing to the CSV file.
+     * @return The resolved {@code Path} pointing to the events CSV file.
      */
-    protected Path getImportPath(Model model) {
+    protected Path getEventsImportPath(Model model) {
         Path userPrefParentDirPath = model.getAddressBookFilePath().getParent();
-        return userPrefParentDirPath.resolve(filename + FILENAME_SUFFIX);
+        return userPrefParentDirPath.resolve(filename + "_events.csv");
+    }
+
+    /**
+     * Returns the path to the persons CSV file to be imported, resolved relative to the
+     * directory containing the current AddressBook data file.
+     *
+     * @param model {@code Model} used to get the base file path from user preferences.
+     * @return The resolved {@code Path} pointing to the persons CSV file.
+     */
+    protected Path getPersonsImportPath(Model model) {
+        Path userPrefParentDirPath = model.getAddressBookFilePath().getParent();
+        return userPrefParentDirPath.resolve(filename + "_persons.csv");
     }
 
     /**
@@ -426,6 +569,6 @@ public class ImportCommand extends Command {
      */
     @Override
     public String toString() {
-        return String.format("Importing list from: %s", filename + FILENAME_SUFFIX);
+        return String.format("Importing list from: %s", filename);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
@@ -8,12 +8,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.util.CsvUtil.splitCsvLine;
 import static seedu.address.commons.util.CsvUtil.unwrapValue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.logic.commands.ImportCommand.FILENAME_SUFFIX;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -45,30 +45,34 @@ public class ExportCommandTest {
 
     @AfterEach
     public void cleanUp() throws Exception {
-        Path path = model.getAddressBookFilePath().getParent().resolve(testFileName + ".csv");
-        Files.deleteIfExists(path);
+        Path personsPath = model.getAddressBookFilePath().getParent().resolve(testFileName + "_persons.csv");
+        Path eventsPath = model.getAddressBookFilePath().getParent().resolve(testFileName + "_events.csv");
+        Files.deleteIfExists(personsPath);
+        Files.deleteIfExists(eventsPath);
     }
 
     @Test
     public void execute_exportAll_success() {
         ExportCommand exportCommand = new ExportCommand("all", testFileName);
-        String expectedMessage = String.format(ExportCommand.MESSAGE_SUCCESS, testFileName + ".csv");
+        String expectedMessage = String.format(ExportCommand.MESSAGE_SUCCESS, testFileName);
 
         assertCommandSuccess(exportCommand, model, expectedMessage, expectedModel);
 
-        Path path = model.getAddressBookFilePath().getParent().resolve(testFileName + ".csv");
-        assertTrue(Files.exists(path));
+        Path personsPath = model.getAddressBookFilePath().getParent().resolve(testFileName + "_persons.csv");
+        Path eventsPath = model.getAddressBookFilePath().getParent().resolve(testFileName + "_events.csv");
+        assertTrue(Files.exists(personsPath));
+        assertTrue(Files.exists(eventsPath));
     }
 
     @Test
     public void execute_exportAll_headerHasExpectedColumnsInOrder() throws Exception {
         ExportCommand exportCommand = new ExportCommand("all", testFileName);
-        String expectedMessage = String.format(ExportCommand.MESSAGE_SUCCESS, testFileName + ".csv");
+        String expectedMessage = String.format(ExportCommand.MESSAGE_SUCCESS, testFileName);
 
         assertCommandSuccess(exportCommand, model, expectedMessage, expectedModel);
 
-        Path path = model.getAddressBookFilePath().getParent().resolve(testFileName + ".csv");
-        List<String> lines = Files.readAllLines(path);
+        Path personsPath = model.getAddressBookFilePath().getParent().resolve(testFileName + "_persons.csv");
+        List<String> lines = Files.readAllLines(personsPath);
         String[] headerColumns = splitCsvLine(lines.get(0));
 
         assertEquals(8, headerColumns.length);
@@ -77,9 +81,37 @@ public class ExportCommandTest {
         assertEquals("Email", headerColumns[2]);
         assertEquals("Address", headerColumns[3]);
         assertEquals("Tags", headerColumns[4]);
-        assertEquals("Events", headerColumns[5]);
+        assertEquals("EventIds", headerColumns[5]);
         assertEquals("Photo", headerColumns[6]);
         assertEquals("Pinned", headerColumns[7]);
+
+        // Every exported person row should stay at the fixed 8-column schema.
+        for (int i = 1; i < lines.size(); i++) {
+            assertEquals(8, splitCsvLine(lines.get(i)).length);
+        }
+    }
+
+    @Test
+    public void execute_exportAll_eventsHeaderHasExpectedColumnsInOrder() throws Exception {
+        ExportCommand exportCommand = new ExportCommand("all", testFileName);
+        String expectedMessage = String.format(ExportCommand.MESSAGE_SUCCESS, testFileName);
+
+        assertCommandSuccess(exportCommand, model, expectedMessage, expectedModel);
+
+        Path eventsPath = model.getAddressBookFilePath().getParent().resolve(testFileName + "_events.csv");
+        List<String> lines = Files.readAllLines(eventsPath);
+        String[] headerColumns = splitCsvLine(lines.get(0));
+
+        assertEquals(5, headerColumns.length);
+        assertEquals("EventId", headerColumns[0]);
+        assertEquals("Title", headerColumns[1]);
+        assertEquals("Description", headerColumns[2]);
+        assertEquals("Start", headerColumns[3]);
+        assertEquals("End", headerColumns[4]);
+
+        for (int i = 1; i < lines.size(); i++) {
+            assertEquals(5, splitCsvLine(lines.get(i)).length);
+        }
     }
 
     @Test
@@ -88,7 +120,7 @@ public class ExportCommandTest {
         expectedModel.updateFilteredPersonList(p -> p.getName().fullName.contains("Alice"));
 
         ExportCommand exportCommand = new ExportCommand("current", testFileName);
-        String expectedMessage = String.format(ExportCommand.MESSAGE_SUCCESS, testFileName + ".csv");
+        String expectedMessage = String.format(ExportCommand.MESSAGE_SUCCESS, testFileName);
 
         assertCommandSuccess(exportCommand, model, expectedMessage, expectedModel);
     }
@@ -111,18 +143,24 @@ public class ExportCommandTest {
         modelWithPinnedPerson.pinPerson(pinnedPerson);
         expectedModelWithPinnedPerson.pinPerson(pinnedPerson);
 
-        Path sharedFilePath = testFolder.resolve(testFileName + ".csv");
+        Path personsFilePath = testFolder.resolve(testFileName + "_persons.csv");
+        Path eventsFilePath = testFolder.resolve(testFileName + "_events.csv");
         ExportCommand exportCommand = new ExportCommand("all", testFileName) {
             @Override
-            protected Path getExportPath(Model model) {
-                return sharedFilePath;
+            protected Path getPersonsExportPath(Model model) {
+                return personsFilePath;
+            }
+
+            @Override
+            protected Path getEventsExportPath(Model model) {
+                return eventsFilePath;
             }
         };
 
-        String expectedMessage = String.format(ExportCommand.MESSAGE_SUCCESS, testFileName + ".csv");
+        String expectedMessage = String.format(ExportCommand.MESSAGE_SUCCESS, testFileName);
         assertCommandSuccess(exportCommand, modelWithPinnedPerson, expectedMessage, expectedModelWithPinnedPerson);
 
-        List<String> lines = Files.readAllLines(sharedFilePath);
+        List<String> lines = Files.readAllLines(personsFilePath);
         String[] headerColumns = splitCsvLine(lines.get(0));
         String[] rowColumns = splitCsvLine(lines.get(1));
 
@@ -147,17 +185,23 @@ public class ExportCommandTest {
         Model modelWithUnpinnedPerson = new ModelManager();
         modelWithUnpinnedPerson.addPerson(unpinnedPerson);
 
-        Path sharedFilePath = testFolder.resolve("exportUnpinned.csv");
+        Path personsFilePath = testFolder.resolve("exportUnpinned_persons.csv");
+        Path eventsFilePath = testFolder.resolve("exportUnpinned_events.csv");
         ExportCommand exportCommand = new ExportCommand("all", "exportUnpinned") {
             @Override
-            protected Path getExportPath(Model model) {
-                return sharedFilePath;
+            protected Path getPersonsExportPath(Model model) {
+                return personsFilePath;
+            }
+
+            @Override
+            protected Path getEventsExportPath(Model model) {
+                return eventsFilePath;
             }
         };
 
         exportCommand.execute(modelWithUnpinnedPerson);
 
-        List<String> lines = Files.readAllLines(sharedFilePath);
+        List<String> lines = Files.readAllLines(personsFilePath);
         String[] rowColumns = splitCsvLine(lines.get(1));
         assertEquals("Unpinned Person", rowColumns[0]);
         assertEquals("false", unwrapValue(rowColumns[7]));
@@ -186,17 +230,23 @@ public class ExportCommandTest {
         modelWithMixedPersons.pinPerson(pinnedCurrent);
         modelWithMixedPersons.updateFilteredPersonList(p -> p.getName().fullName.equals("Current Pinned"));
 
-        Path sharedFilePath = testFolder.resolve("exportCurrentPinned.csv");
+        Path personsFilePath = testFolder.resolve("exportCurrentPinned_persons.csv");
+        Path eventsFilePath = testFolder.resolve("exportCurrentPinned_events.csv");
         ExportCommand exportCommand = new ExportCommand("current", "exportCurrentPinned") {
             @Override
-            protected Path getExportPath(Model model) {
-                return sharedFilePath;
+            protected Path getPersonsExportPath(Model model) {
+                return personsFilePath;
+            }
+
+            @Override
+            protected Path getEventsExportPath(Model model) {
+                return eventsFilePath;
             }
         };
 
         exportCommand.execute(modelWithMixedPersons);
 
-        List<String> lines = Files.readAllLines(sharedFilePath);
+        List<String> lines = Files.readAllLines(personsFilePath);
         assertEquals(2, lines.size()); // header + only one filtered row
 
         String[] rowColumns = splitCsvLine(lines.get(1));
@@ -234,12 +284,18 @@ public class ExportCommandTest {
         model.addPerson(originalPerson);
 
         String filename = "exportImport";
-        Path sharedFilePath = testFolder.resolve(filename + FILENAME_SUFFIX);
+        Path personsFilePath = testFolder.resolve(filename + "_persons.csv");
+        Path eventsFilePath = testFolder.resolve(filename + "_events.csv");
 
         ExportCommand exportCommand = new ExportCommand("all", filename) {
             @Override
-            protected Path getExportPath(Model model) {
-                return sharedFilePath;
+            protected Path getPersonsExportPath(Model model) {
+                return personsFilePath;
+            }
+
+            @Override
+            protected Path getEventsExportPath(Model model) {
+                return eventsFilePath;
             }
         };
         exportCommand.execute(model);
@@ -249,15 +305,24 @@ public class ExportCommandTest {
 
         ImportCommand importCommand = new ImportCommand("add", filename) {
             @Override
-            protected Path getImportPath(Model model) {
-                return sharedFilePath;
+            protected Path getPersonsImportPath(Model model) {
+                return personsFilePath;
+            }
+
+            @Override
+            protected Path getEventsImportPath(Model model) {
+                return eventsFilePath;
             }
         };
         importCommand.execute(model);
 
         assertTrue(model.hasPerson(originalPerson), "Test person was not reconstructed correctly.");
 
-        Person importedPerson = model.getFilteredPersonList().get(0);
+        Optional<Person> importedPersonOpt = model.getAddressBook().getPersonList().stream()
+                .filter(originalPerson::isSamePerson)
+                .findFirst();
+        assertTrue(importedPersonOpt.isPresent(), "Imported person not found in address book.");
+        Person importedPerson = importedPersonOpt.get();
         assertEquals(originalPerson.getAddress(), importedPerson.getAddress(),
                 "Address with commas failed round-trip integrity!");
     }
@@ -278,12 +343,18 @@ public class ExportCommandTest {
         model.addPerson(originalPerson);
 
         String filename = "exportImportMultipleEvents";
-        Path sharedFilePath = testFolder.resolve(filename + FILENAME_SUFFIX);
+        Path personsFilePath = testFolder.resolve(filename + "_persons.csv");
+        Path eventsFilePath = testFolder.resolve(filename + "_events.csv");
 
         ExportCommand exportCommand = new ExportCommand("all", filename) {
             @Override
-            protected Path getExportPath(Model model) {
-                return sharedFilePath;
+            protected Path getPersonsExportPath(Model model) {
+                return personsFilePath;
+            }
+
+            @Override
+            protected Path getEventsExportPath(Model model) {
+                return eventsFilePath;
             }
         };
         exportCommand.execute(model);
@@ -292,17 +363,32 @@ public class ExportCommandTest {
 
         ImportCommand importCommand = new ImportCommand("add", filename) {
             @Override
-            protected Path getImportPath(Model model) {
-                return sharedFilePath;
+            protected Path getPersonsImportPath(Model model) {
+                return personsFilePath;
+            }
+
+            @Override
+            protected Path getEventsImportPath(Model model) {
+                return eventsFilePath;
             }
         };
         importCommand.execute(model);
 
-        Person importedPerson = model.getFilteredPersonList().get(0);
+        Optional<Person> importedPersonOpt = model.getAddressBook().getPersonList().stream()
+                .filter(originalPerson::isSamePerson)
+                .findFirst();
+        assertTrue(importedPersonOpt.isPresent(), "Imported person not found in address book.");
+        Person importedPerson = importedPersonOpt.get();
         assertEquals(2, importedPerson.getEvents().size());
 
-        Event firstEvent = importedPerson.getEvents().get(0);
-        Event secondEvent = importedPerson.getEvents().get(1);
+        Event firstEvent = importedPerson.getEvents().stream()
+                .filter(e -> e.getTitle().fullTitle.equals("Meeting"))
+                .findFirst()
+                .orElseThrow();
+        Event secondEvent = importedPerson.getEvents().stream()
+                .filter(e -> e.getTitle().fullTitle.equals("Lunch"))
+                .findFirst()
+                .orElseThrow();
 
         assertEquals("Meeting", firstEvent.getTitle().fullTitle);
         assertEquals("Kickoff", firstEvent.getDescription().orElseThrow().fullDescription);
@@ -322,7 +408,12 @@ public class ExportCommandTest {
 
         ExportCommand exportCommand = new ExportCommand("all", "directoryExport") {
             @Override
-            protected Path getExportPath(Model model) {
+            protected Path getPersonsExportPath(Model model) {
+                return exportDirectory;
+            }
+
+            @Override
+            protected Path getEventsExportPath(Model model) {
                 return exportDirectory;
             }
         };
@@ -350,6 +441,6 @@ public class ExportCommandTest {
     @Test
     public void toString_returnsExpectedString() {
         ExportCommand exportCommand = new ExportCommand("current", "myFile");
-        assertEquals("Exporting list to: myFile.csv", exportCommand.toString());
+        assertEquals("Exporting list to: myFile", exportCommand.toString());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ImportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ImportCommandTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
-import static seedu.address.logic.commands.ImportCommand.FILENAME_SUFFIX;
 import static seedu.address.logic.commands.ImportCommand.MESSAGE_ERROR_READING_FILE;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
@@ -39,18 +38,29 @@ public class ImportCommandTest {
     public Path testFolder;
 
     private Model model;
-    private final String header = "Name,Phone,Email,Address,Tags,Events,Photo";
+    private final String personsHeader = "Name,Phone,Email,Address,Tags,EventIds,Photo,Pinned";
+    private final String eventsHeader = "EventId,Title,Description,Start,End";
 
-    private void createCsvFile(String fileName, String content) throws Exception {
-        Path filePath = testFolder.resolve(fileName + FILENAME_SUFFIX);
+    private void createPersonsCsvFile(String fileName, String content) throws Exception {
+        Path filePath = testFolder.resolve(fileName + "_persons.csv");
+        Files.writeString(filePath, content, StandardCharsets.UTF_8);
+    }
+
+    private void createEventsCsvFile(String fileName, String content) throws Exception {
+        Path filePath = testFolder.resolve(fileName + "_events.csv");
         Files.writeString(filePath, content, StandardCharsets.UTF_8);
     }
 
     public ImportCommand createTestCommand(String importType, String filename) {
         return new ImportCommand(importType, filename) {
             @Override
-            protected Path getImportPath(Model model) {
-                return testFolder.resolve(filename + FILENAME_SUFFIX);
+            protected Path getEventsImportPath(Model model) {
+                return testFolder.resolve(filename + "_events.csv");
+            }
+
+            @Override
+            protected Path getPersonsImportPath(Model model) {
+                return testFolder.resolve(filename + "_persons.csv");
             }
         };
     }
@@ -62,8 +72,10 @@ public class ImportCommandTest {
 
     @AfterEach
     public void cleanUp() throws Exception {
-        Path path = model.getAddressBookFilePath().getParent().resolve("test_import" + FILENAME_SUFFIX);
-        Files.deleteIfExists(path);
+        Path personsPath = model.getAddressBookFilePath().getParent().resolve("test_import_persons.csv");
+        Path eventsPath = model.getAddressBookFilePath().getParent().resolve("test_import_events.csv");
+        Files.deleteIfExists(personsPath);
+        Files.deleteIfExists(eventsPath);
     }
 
     @Test
@@ -85,12 +97,13 @@ public class ImportCommandTest {
                 .withAddress("Blk 456")
                 .withTags()
                 .withEvents()
-                .withPhoto("this_is_another.jpg")
+                .withoutPhoto()
                 .build();
 
         model.addPerson(expectedTest1);
 
-        createCsvFile("valid", header + "\nDavid,91234567,david@u.nus.edu,Blk 456,,,");
+        createEventsCsvFile("valid", eventsHeader);
+        createPersonsCsvFile("valid", personsHeader + "\nDavid,91234567,david@u.nus.edu,Blk 456,,,,false");
 
         ImportCommand command = createTestCommand("overwrite", "valid");
         command.execute(model);
@@ -105,12 +118,11 @@ public class ImportCommandTest {
         Person alice = new PersonBuilder().withName("Alice Pauline").withPhone("12345678").build();
         model.addPerson(alice);
 
-        String testString = """
-                \nAlice Pauline,12345678,alice@u.nus.edu,Blk 123,,,
-                \nBob,88662211,bob@u.nus.edu,Blk 123,,,
-                """;
+        String personData = "Alice Pauline,12345678,alice@u.nus.edu,Blk 123,,,,false\n"
+                + "Bob,88662211,bob@u.nus.edu,Blk 123,,,,false";
 
-        createCsvFile("merge", header + testString);
+        createEventsCsvFile("merge", eventsHeader);
+        createPersonsCsvFile("merge", personsHeader + "\n" + personData);
 
         ImportCommand command = createTestCommand("add", "merge");
         command.execute(model);
@@ -140,7 +152,8 @@ public class ImportCommandTest {
                 .withoutPhoto()
                 .build();
 
-        createCsvFile("valid", header + "\nAlice,12345678,,,,,");
+        createEventsCsvFile("valid", eventsHeader);
+        createPersonsCsvFile("valid", personsHeader + "\nAlice,12345678,,,,,,,false");
 
         ImportCommand command = createTestCommand("overwrite", "valid");
         command.execute(model);
@@ -161,7 +174,9 @@ public class ImportCommandTest {
                 .withPhoto("hello_world.jpg")
                 .build();
 
-        createCsvFile("photo", header + "\nAlice,12345678,alice@u.nus.edu,Blk 123,,,hello_world.jpg");
+        String testPersonStr = "\nAlice,12345678,alice@u.nus.edu,Blk 123,,,hello_world.jpg,false";
+        createEventsCsvFile("photo", eventsHeader);
+        createPersonsCsvFile("photo", personsHeader + testPersonStr);
 
         ImportCommand command = createTestCommand("overwrite", "photo");
         command.execute(model);
@@ -194,10 +209,11 @@ public class ImportCommandTest {
                 .withoutPhoto()
                 .build();
 
-        createCsvFile("pinnedAndLegacy",
-                "Name,Phone,Email,Address,Tags,Events,Photo,Pinned\n"
+        createEventsCsvFile("pinnedAndLegacy", eventsHeader);
+        createPersonsCsvFile("pinnedAndLegacy",
+                personsHeader + "\n"
                         + "Pinned Alice,12345678,alice@u.nus.edu,Blk 123,,,,true\n"
-                        + "Legacy Bob,87654321,bob@u.nus.edu,Blk 456,,,");
+                        + "Legacy Bob,87654321,bob@u.nus.edu,Blk 456,,,,false");
 
         ImportCommand command = createTestCommand("overwrite", "pinnedAndLegacy");
         CommandResult result = command.execute(modelWithPins);
@@ -223,8 +239,9 @@ public class ImportCommandTest {
                 .withoutPhoto()
                 .build();
 
-        createCsvFile("pinnedFalse",
-                "Name,Phone,Email,Address,Tags,Events,Photo,Pinned\n"
+        createEventsCsvFile("pinnedFalse", eventsHeader);
+        createPersonsCsvFile("pinnedFalse",
+                personsHeader + "\n"
                         + "Unpinned User,92345678,unpinned@u.nus.edu,Blk 789,,,,false");
 
         ImportCommand command = createTestCommand("overwrite", "pinnedFalse");
@@ -249,8 +266,9 @@ public class ImportCommandTest {
                 .withoutPhoto()
                 .build();
 
-        createCsvFile("invalidPinnedValue",
-                "Name,Phone,Email,Address,Tags,Events,Photo,Pinned\n"
+        createEventsCsvFile("invalidPinnedValue", eventsHeader);
+        createPersonsCsvFile("invalidPinnedValue",
+                personsHeader + "\n"
                         + "Invalid Pin,93456789,invalidpin@u.nus.edu,Blk 111,,,,yes");
 
         ImportCommand command = createTestCommand("overwrite", "invalidPinnedValue");
@@ -274,8 +292,9 @@ public class ImportCommandTest {
                 .withoutPhoto()
                 .build();
 
-        createCsvFile("uppercaseTrue",
-                "Name,Phone,Email,Address,Tags,Events,Photo,Pinned\n"
+        createEventsCsvFile("uppercaseTrue", eventsHeader);
+        createPersonsCsvFile("uppercaseTrue",
+                personsHeader + "\n"
                         + "Case True,94567890,casetrue@u.nus.edu,Blk 222,,,,TRUE");
 
         ImportCommand command = createTestCommand("overwrite", "uppercaseTrue");
@@ -289,38 +308,43 @@ public class ImportCommandTest {
     public void execute_fileNotFound_throwsCommandException() {
         ImportCommand command = createTestCommand("add", "invalid_file");
 
-        String expectedMessage = String.format(MESSAGE_ERROR_READING_FILE, "invalid_file" + FILENAME_SUFFIX);
+        String expectedMessage = String.format(MESSAGE_ERROR_READING_FILE, "invalid_file_events.csv");
         assertCommandFailure(command, model, expectedMessage);
     }
 
     @Test
     public void execute_csvHeaderOnly_returnsEmptyMessage() throws Exception {
-        createCsvFile("empty", header);
+        createEventsCsvFile("empty", eventsHeader);
+        createPersonsCsvFile("empty", personsHeader);
 
         ImportCommand command = createTestCommand("add", "empty");
         CommandResult result = command.execute(model);
 
-        assertEquals(String.format(ImportCommand.MESSAGE_EMPTY_FILE, "empty" + FILENAME_SUFFIX),
+        assertEquals(String.format(ImportCommand.MESSAGE_EMPTY_FILE, "empty_persons.csv"),
                 result.getFeedbackToUser());
     }
 
     @Test
     public void execute_emptyCsvFile_throwsCommandException() throws Exception {
-        Path emptyFilePath = testFolder.resolve("empty" + FILENAME_SUFFIX);
-        Files.write(emptyFilePath, new byte[0]);
+        Path emptyEventsPath = testFolder.resolve("empty_events.csv");
+        Path emptyPersonsPath = testFolder.resolve("empty_persons.csv");
+        Files.write(emptyEventsPath, new byte[0]);
+        Files.write(emptyPersonsPath, new byte[0]);
 
         ImportCommand command = createTestCommand("add", "empty");
 
         CommandException exception = assertThrows(CommandException.class, () -> command.execute(model));
-        assertEquals(String.format(ImportCommand.MESSAGE_EMPTY_FILE, "empty" + FILENAME_SUFFIX),
+        assertEquals(String.format(ImportCommand.MESSAGE_EMPTY_FILE, "empty_events.csv"),
                 exception.getMessage());
     }
 
     @Test
     public void execute_rowsWithAndWithoutPhoto_importsBothPersons() throws Exception {
-        String testString = "\nPhoto User,81234567,photo@u.nus.edu,Blk 123,,,avatar.png"
-                + "\nNo Photo,82345678,nophoto@u.nus.edu,Blk 456,,,";
-        createCsvFile("mixedPhoto", header + testString);
+        String personData = "Photo User,81234567,photo@u.nus.edu,Blk 123,,,avatar.png,false\n"
+                + "No Photo,82345678,nophoto@u.nus.edu,Blk 456,,,,false";
+
+        createEventsCsvFile("mixedPhoto", eventsHeader);
+        createPersonsCsvFile("mixedPhoto", personsHeader + "\n" + personData);
 
         ImportCommand command = createTestCommand("overwrite", "mixedPhoto");
         command.execute(model);
@@ -346,9 +370,11 @@ public class ImportCommandTest {
 
     @Test
     public void execute_invalidDataRow_skipsAndReports() throws Exception {
-        String testString = "\nValid,91234567,valid@u.nus.edu,Blk 123,,,\nInvalid,abcd,invalid@u.nus.edu,Blk 123,,,";
+        String personData = "Valid,91234567,valid@u.nus.edu,Blk 123,,,,false\n"
+                + "Invalid,abcd,invalid@u.nus.edu,Blk 123,,,,false";
 
-        createCsvFile("invalidRow", header + testString);
+        createEventsCsvFile("invalidRow", eventsHeader);
+        createPersonsCsvFile("invalidRow", personsHeader + "\n" + personData);
 
         ImportCommand command = createTestCommand("add", "invalidRow");
         CommandResult result = command.execute(model);
@@ -367,8 +393,11 @@ public class ImportCommandTest {
         model.addEvent(existingEvent);
         int eventCountBeforeImport = model.getAddressBook().getEventList().size();
 
-        createCsvFile("eventExists", header
-                + "\nEve,81234567,eve@u.nus.edu,Blk 321,,Meeting|Kickoff|2026-05-06 1000|2026-05-06 1100|1|500,");
+        int eventId = existingEvent.getEventId();
+        String testEventStr = "\n" + eventId + ",Meeting,Kickoff,2026-05-06 1000,2026-05-06 1100";
+        String testPersonStr = "\nEve,81234567,eve@u.nus.edu,Blk 321,," + eventId + ",,false";
+        createEventsCsvFile("eventExists", eventsHeader + testEventStr);
+        createPersonsCsvFile("eventExists", personsHeader + testPersonStr);
 
         ImportCommand command = createTestCommand("add", "eventExists");
         CommandResult result = command.execute(model);
@@ -387,8 +416,8 @@ public class ImportCommandTest {
         model.addEvent(existingEvent);
         int eventCountBeforeImport = model.getAddressBook().getEventList().size();
 
-        createCsvFile("eventOverlap", header
-                + "\nEve,81234567,eve@u.nus.edu,Blk 321,,Consult|Discussion|2026-05-06 1000|2026-05-06 1100|1|501,");
+        createEventsCsvFile("eventOverlap", eventsHeader + "\n888,Consult,Discussion,2026-05-06 1000,2026-05-06 1100");
+        createPersonsCsvFile("eventOverlap", personsHeader + "\nEve,81234567,eve@u.nus.edu,Blk 321,,888,,false");
 
         ImportCommand command = createTestCommand("add", "eventOverlap");
         CommandResult result = command.execute(model);
@@ -402,22 +431,29 @@ public class ImportCommandTest {
     public void execute_fileDoesNotExist_throwsCommandException() {
         ImportCommand importCommand = new ImportCommand("add", "nonExistentFile");
         assertCommandFailure(importCommand, model,
-                String.format(ImportCommand.MESSAGE_ERROR_READING_FILE, "nonExistentFile.csv"));
+                String.format(ImportCommand.MESSAGE_ERROR_READING_FILE, "nonExistentFile_events.csv"));
     }
 
     @Test
     public void execute_headerOnlyFile_returnsEmptyFileMessage() throws Exception {
-        Path filePath = testFolder.resolve("empty.csv");
-        Files.writeString(filePath, "Name,Phone,Email,Address,Tags,Events,Photo");
+        Path eventsPath = testFolder.resolve("empty_events.csv");
+        Path personsPath = testFolder.resolve("empty_persons.csv");
+        Files.writeString(eventsPath, eventsHeader);
+        Files.writeString(personsPath, personsHeader);
 
         ImportCommand importCommand = new ImportCommand("add", "empty") {
             @Override
-            protected Path getImportPath(Model model) {
-                return filePath;
+            protected Path getEventsImportPath(Model model) {
+                return eventsPath;
+            }
+
+            @Override
+            protected Path getPersonsImportPath(Model model) {
+                return personsPath;
             }
         };
 
-        String expectedMessage = String.format(ImportCommand.MESSAGE_EMPTY_FILE, "empty.csv");
+        String expectedMessage = String.format(ImportCommand.MESSAGE_EMPTY_FILE, "empty_persons.csv");
         CommandResult result = importCommand.execute(model);
         assertEquals(expectedMessage, result.getFeedbackToUser());
     }
@@ -430,37 +466,50 @@ public class ImportCommandTest {
 
         ImportCommand importCommand = new ImportCommand("add", dirname) {
             @Override
-            protected Path getImportPath(Model model) {
+            protected Path getEventsImportPath(Model model) {
                 return dirPath;
+            }
+
+            @Override
+            protected Path getPersonsImportPath(Model model) {
+                return dirPath.resolve(dirname + "_persons.csv");
             }
         };
 
-        String expectedMessage = String.format(ImportCommand.MESSAGE_ERROR_READING_FILE, dirname + ".csv");
+        String expectedMessage = String.format(ImportCommand.MESSAGE_ERROR_READING_FILE, dirname + "_events.csv");
 
         assertThrows(CommandException.class, () -> importCommand.execute(model), expectedMessage);
     }
 
     @Test
     public void processImportedLines_invalidColumnCount_skipsRow() throws Exception {
-        Path filePath = testFolder.resolve("malformed.csv");
-        List<String> lines = List.of(
-                "Name,Phone,Email,Address,Tags,Events,Photo",
+        Path eventsPath = testFolder.resolve("malformed_events.csv");
+        Path personsPath = testFolder.resolve("malformed_persons.csv");
+        List<String> eventsLines = List.of(eventsHeader);
+        List<String> personLines = List.of(
+                personsHeader,
                 "John Doe,91234567",
-                "Yohan,67676868,,,,,"
+                "Yohan,67676868,,,"
         );
-        Files.write(filePath, lines);
+        Files.write(eventsPath, eventsLines);
+        Files.write(personsPath, personLines);
 
         ImportCommand importCommand = new ImportCommand("add", "malformed") {
             @Override
-            protected Path getImportPath(Model model) {
-                return filePath;
+            protected Path getEventsImportPath(Model model) {
+                return eventsPath;
+            }
+
+            @Override
+            protected Path getPersonsImportPath(Model model) {
+                return personsPath;
             }
         };
 
         CommandResult result = importCommand.execute(model);
 
         String expectedFeedback = String.format(ImportCommand.MESSAGE_SUCCESS_ROWS_ADDED_SKIPPED,
-                "malformed.csv", 1, 1);
+                "malformed", 0, 2);
         assertEquals(expectedFeedback, result.getFeedbackToUser());
     }
 
@@ -585,7 +634,9 @@ public class ImportCommandTest {
 
     @Test
     public void execute_rowWithTags_importsPerson() throws Exception {
-        createCsvFile("tagged", header + "\nCharlie,87654321,charlie@u.nus.edu,Blk 789,friends;CS2103,,");
+        String testPersonStr = "\nCharlie,87654321,charlie@u.nus.edu,Blk 789,friends;CS2103,,,false";
+        createEventsCsvFile("tagged", eventsHeader);
+        createPersonsCsvFile("tagged", personsHeader + testPersonStr);
 
         ImportCommand command = createTestCommand("add", "tagged");
         CommandResult result = command.execute(model);
@@ -595,13 +646,61 @@ public class ImportCommandTest {
 
     @Test
     public void execute_rowWithEvents_importsPerson() throws Exception {
-        createCsvFile("withevents", header
-                + "\nEve,81234567,eve@u.nus.edu,Blk 321,,Meeting|Kickoff|2026-05-06 1000|2026-05-06 1100|1|500,");
+        int eventId = 500;
+        String testEventStr = eventId + ",Meeting,Kickoff,2026-05-06 1000,2026-05-06 1100";
+        String testPersonStr = "\nEve,81234567,eve@u.nus.edu,Blk 321,," + eventId + ",,false";
+        createEventsCsvFile("withevents", eventsHeader + "\n" + testEventStr);
+        createPersonsCsvFile("withevents", personsHeader + testPersonStr);
 
         ImportCommand command = createTestCommand("add", "withevents");
         CommandResult result = command.execute(model);
 
         assertTrue(result.getFeedbackToUser().contains("1 row(s) added"));
+    }
+
+    @Test
+    public void execute_eventsCsvContainsBlankLine_skipsBlankEventEntryAndImportsPerson() throws Exception {
+        createEventsCsvFile("blankEventLine", eventsHeader + "\n   ");
+        createPersonsCsvFile("blankEventLine",
+                personsHeader + "\nBlank Event User,81231234,blank@u.nus.edu,Blk 10,,,,false");
+
+        ImportCommand command = createTestCommand("overwrite", "blankEventLine");
+        CommandResult result = command.execute(model);
+
+        Person expectedPerson = new PersonBuilder()
+                .withName("Blank Event User")
+                .withPhone("81231234")
+                .withEmail("blank@u.nus.edu")
+                .withAddress("Blk 10")
+                .withoutPhoto()
+                .build();
+
+        assertTrue(result.getFeedbackToUser().contains("1 row(s) added"));
+        assertTrue(model.hasPerson(expectedPerson));
+        assertEquals(0, model.getAddressBook().getEventList().size());
+    }
+
+    @Test
+    public void execute_eventsCsvMalformedRow_triggersCatchAndContinuesImportingPersons() throws Exception {
+        // Missing required event columns causes IllegalArgumentException in event parsing.
+        createEventsCsvFile("malformedEventRow", eventsHeader + "\n999,OnlyTitle");
+        createPersonsCsvFile("malformedEventRow",
+                personsHeader + "\nMalformed Event User,81239999,malformed@u.nus.edu,Blk 11,,,,false");
+
+        ImportCommand command = createTestCommand("overwrite", "malformedEventRow");
+        CommandResult result = command.execute(model);
+
+        Person expectedPerson = new PersonBuilder()
+                .withName("Malformed Event User")
+                .withPhone("81239999")
+                .withEmail("malformed@u.nus.edu")
+                .withAddress("Blk 11")
+                .withoutPhoto()
+                .build();
+
+        assertTrue(result.getFeedbackToUser().contains("1 row(s) added"));
+        assertTrue(model.hasPerson(expectedPerson));
+        assertEquals(0, model.getAddressBook().getEventList().size());
     }
 
     @Test
@@ -727,6 +826,78 @@ public class ImportCommandTest {
     }
 
     @Test
+    public void parseLineToEvent_nullLine_returnsEmptyOptional() {
+        ImportCommand importCommand = new ImportCommand("add", "testFile");
+        assertTrue(importCommand.parseLineToEvent(null).isEmpty());
+    }
+
+    @Test
+    public void parseLineToEvent_blankLine_returnsEmptyOptional() {
+        ImportCommand importCommand = new ImportCommand("add", "testFile");
+        assertTrue(importCommand.parseLineToEvent("   ").isEmpty());
+    }
+
+    @Test
+    public void createEventFromCsvRow_missingRequiredFields_throwsIllegalArgumentException() {
+        ImportCommand importCommand = new ImportCommand("add", "testFile");
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
+                importCommand.createEventFromCsvRow("101,,desc,2026-05-06 1000,2026-05-06 1100"));
+        assertEquals("Event has missing required fields", exception.getMessage());
+    }
+
+    @Test
+    public void createEventFromCsvRow_missingStartOrEnd_throwsIllegalArgumentException() {
+        ImportCommand importCommand = new ImportCommand("add", "testFile");
+
+        IllegalArgumentException missingStart = assertThrows(IllegalArgumentException.class, () ->
+                importCommand.createEventFromCsvRow("101,Meeting,desc,,2026-05-06 1100"));
+        assertEquals("Event has missing required fields", missingStart.getMessage());
+
+        IllegalArgumentException missingEnd = assertThrows(IllegalArgumentException.class, () ->
+                importCommand.createEventFromCsvRow("101,Meeting,desc,2026-05-06 1000,"));
+        assertEquals("Event has missing required fields", missingEnd.getMessage());
+    }
+
+    @Test
+    public void createEventFromCsvRow_nonNumericEventId_throwsIllegalArgumentException() {
+        ImportCommand importCommand = new ImportCommand("add", "testFile");
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
+                importCommand.createEventFromCsvRow("abc,Meeting,desc,2026-05-06 1000,2026-05-06 1100"));
+        assertEquals("Event ID must be a valid integer", exception.getMessage());
+    }
+
+    @Test
+    public void parseEventIds_nullOrBlank_returnsEmptyList() {
+        ImportCommand importCommand = new ImportCommand("add", "testFile");
+
+        assertTrue(importCommand.parseEventIds(null, new HashMap<>()).isEmpty());
+        assertTrue(importCommand.parseEventIds("   ", new HashMap<>()).isEmpty());
+    }
+
+    @Test
+    public void parseEventIds_existingAndInvalidIds_handlesAllBranches() {
+        ImportCommand importCommand = new ImportCommand("add", "testFile");
+        HashMap<Integer, Event> eventMap = new HashMap<>();
+
+        Event existingEvent = new Event(
+                new Title("Meeting"),
+                Optional.of(new Description("Kickoff")),
+                new TimeRange("2026-05-06 1000", "2026-05-06 1100")
+        );
+        eventMap.put(100, existingEvent);
+
+        List<Event> result = importCommand.parseEventIds("100;999;abc", eventMap);
+
+        // Inside the parseEventIds() method,
+        // event ID '100' covers the 'event != null' branch, event ID '999' covers the 'else' branch,
+        // and event ID 'abc' covers the NumberFormatException branch.
+        assertEquals(1, result.size());
+        assertSame(existingEvent, result.get(0));
+    }
+
+    @Test
     public void equals() {
         ImportCommand importFirst = new ImportCommand("overwrite", "file1");
         ImportCommand importSecond = new ImportCommand("overwrite", "file1");
@@ -747,6 +918,6 @@ public class ImportCommandTest {
     @Test
     public void toString_returnsExpectedString() {
         ImportCommand importCommand = new ImportCommand("add", "myFile");
-        assertEquals("Importing list from: myFile.csv", importCommand.toString());
+        assertEquals("Importing list from: myFile", importCommand.toString());
     }
 }


### PR DESCRIPTION
## Summary
- Refactored CSV import/export to a dual-file format for stronger data integrity and clearer validation paths.
- `export ...` now writes persons and events separately
- `import ...` reconstructs persons by linking event IDs to canonical event definitions.

## What Changed
- Import (`ImportCommand`)
  - Import now reads from two files: 
    - `<filename>_persons.csv`
    - `<filename>_events.csv`
  - Events are parsed first into an `eventMap` keyed by `EventId`, then persons are parsed and linked via `EventIds`.
  - Invalid/malformed event rows are skipped safely without aborting full import.
  - Blank event rows are treated as empty entries.
  - Person rows with invalid structure/data are skipped; result reports added vs skipped rows.

- Export (`ExportCommand`)
  - Export now generates two files per command:
    - `<filename>_persons.csv`
    - `<filename>_events.csv`
  - Person rows store only event ID references, whereas event definitions are centralized in the `<filename>_events.csv` file.

Closes #256.