### PR TITLE
Fix error handling for `export` command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ExportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExportCommand.java
@@ -25,6 +25,7 @@ import seedu.address.model.person.Photo;
  * - {filename}_events.csv containing all unique events
  */
 public class ExportCommand extends Command {
+    public static final String MESSAGE_EMPTY_EXPORT = "Nothing to export: There are no contacts.";
 
     public static final String COMMAND_WORD = "export";
 
@@ -91,8 +92,10 @@ public class ExportCommand extends Command {
         requireNonNull(model);
 
         List<Person> exportedList = getExportedList(model);
+        if (exportedList.isEmpty()) {
+            throw new CommandException(MESSAGE_EMPTY_EXPORT);
+        }
 
-        // Collect all unique events referenced by exported persons
         Set<Event> uniqueEvents = collectUniqueEvents(exportedList);
 
         Path personsExportPath = getPersonsExportPath(model);

--- a/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
@@ -126,6 +126,22 @@ public class ExportCommandTest {
     }
 
     @Test
+    public void execute_exportCurrentEmptyFilteredList_throwsCommandException() {
+        model.updateFilteredPersonList(p -> false);
+        ExportCommand exportCommand = new ExportCommand("current", testFileName);
+        CommandException thrown = assertThrows(CommandException.class, () -> exportCommand.execute(model));
+        assertEquals(ExportCommand.MESSAGE_EMPTY_EXPORT, thrown.getMessage());
+    }
+
+    @Test
+    public void execute_exportAllEmptyAddressBook_throwsCommandException() {
+        model.setAddressBook(new AddressBook());
+        ExportCommand exportCommand = new ExportCommand("all", testFileName);
+        CommandException thrown = assertThrows(CommandException.class, () -> exportCommand.execute(model));
+        assertEquals(ExportCommand.MESSAGE_EMPTY_EXPORT, thrown.getMessage());
+    }
+
+    @Test
     public void execute_exportPinnedPerson_writesPinnedColumn() throws Exception {
         Person pinnedPerson = new PersonBuilder()
                 .withName("Pinned Person")


### PR DESCRIPTION
## Summary
This PR improves the `ExportCommand` by adding validation to prevent exporting when there are no contacts, and adds corresponding tests to ensure this behavior is handled correctly.

* Added a new error message constant `MESSAGE_EMPTY_EXPORT` to `ExportCommand` to indicate when there are no contacts to export.

* Updated the `execute` method in `ExportCommand` to throw a `CommandException` with `MESSAGE_EMPTY_EXPORT` if the list of contacts to export is empty.

* Added two tests in `ExportCommandTest` to verify that exporting with an empty filtered list or an empty address book throws a `CommandException` with the correct message.

## LoC Changed 
  * **4**, excluding test cases

Fixes #360.