### PR TITLE
Fix: Delete command always clear event panel

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -66,13 +66,16 @@ public class DeleteCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         Person personToDelete = CommandUtil.targetPerson(model, this.targetInfo);
+        boolean isShowingDeletedPerson = model.isShowingEventsFor(personToDelete);
         if (personToDelete.getPhoto().isPresent()) {
             CommandUtil.safelyDeletePhoto(model, personToDelete, personToDelete.getPhoto().get(),
                     this.targetDirectory);
         }
 
         model.deletePerson(personToDelete);
-        model.showNoEvents();
+        if (isShowingDeletedPerson) {
+            model.showNoEvents();
+        }
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.format(personToDelete)));
     }
 

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -200,6 +200,7 @@ public interface Model {
      * and the filtered person list to show only {@code person}.
      */
     void showEventsForPerson(Person person);
+
     /**
      * Returns true if the current view is showing only {@code person} together with that person's events.
      */

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -286,6 +286,7 @@ public class ModelManager implements Model {
         sortedPersons.setComparator(null);
         updateFilteredEventList(person::hasEvent);
     }
+
     @Override
     public boolean isShowingEventsFor(Person person) {
         requireNonNull(person);

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -12,6 +12,7 @@ import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -22,10 +23,12 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.event.Event;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.PersonInformation;
 import seedu.address.model.person.Phone;
+import seedu.address.model.util.SampleDataUtil;
 import seedu.address.testutil.PersonBuilder;
 
 /**
@@ -162,6 +165,24 @@ public class DeleteCommandTest {
         deleteCommand.execute(model);
 
         assertTrue(model.getFilteredEventList().isEmpty());
+    }
+
+    @Test
+    public void execute_otherPersonDeleted_preservesDisplayedSharedEvents() throws Exception {
+        Model sharedEventModel = new ModelManager(SampleDataUtil.getSampleAddressBook(), new UserPrefs());
+        Person displayedPerson = sharedEventModel.findPersons(createNameOnlyInfo(new Name("Bernice Yu"))).get(0);
+        Person personToDelete = sharedEventModel.findPersons(createNameOnlyInfo(new Name("Alex Yeoh"))).get(0);
+
+        sharedEventModel.showEventsForPerson(displayedPerson);
+        List<Event> eventsBeforeDelete = List.copyOf(sharedEventModel.getFilteredEventList());
+        assertFalse(eventsBeforeDelete.isEmpty());
+
+        DeleteCommand deleteCommand = new DeleteCommand(createNameOnlyInfo(personToDelete.getName()));
+        deleteCommand.execute(sharedEventModel);
+
+        assertEquals(1, sharedEventModel.getFilteredPersonList().size());
+        assertTrue(sharedEventModel.getFilteredPersonList().get(0).isSamePerson(displayedPerson));
+        assertEquals(eventsBeforeDelete, List.copyOf(sharedEventModel.getFilteredEventList()));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -409,6 +409,33 @@ public class ModelManagerTest {
     }
 
     @Test
+    public void isShowingEventsFor_whenShowingPersonEvents_returnsTrue() {
+        Person personWithEvent = new PersonBuilder().withName("Eve Tan").withPhone("91110000").build();
+        modelManager.addPerson(personWithEvent);
+        Event event = newEvent("Consult", null, "2026-03-27 0900", "2026-03-27 1000");
+        modelManager.addEvent(event);
+        personWithEvent.addEvent(event);
+
+        modelManager.showEventsForPerson(personWithEvent);
+
+        assertTrue(modelManager.isShowingEventsFor(personWithEvent));
+    }
+
+    @Test
+    public void isShowingEventsFor_whenEventsNotShown_returnsFalse() {
+        Person personWithEvent = new PersonBuilder().withName("Eve Tan").withPhone("91110000").build();
+        modelManager.addPerson(personWithEvent);
+        Event event = newEvent("Consult", null, "2026-03-27 0900", "2026-03-27 1000");
+        modelManager.addEvent(event);
+        personWithEvent.addEvent(event);
+
+        modelManager.showEventsForPerson(personWithEvent);
+        modelManager.showNoEvents();
+
+        assertFalse(modelManager.isShowingEventsFor(personWithEvent));
+    }
+
+    @Test
     public void findPersons_matchesByNameOnly_returnsMatchingPersons() {
         modelManager.addPerson(ALICE);
         modelManager.addPerson(BENSON);


### PR DESCRIPTION
## Description
- [x] Clear the event panel only if the contact panel is currently displaying the person to be deleted
- [x] Updated test cases

Fixes #376 