### PR TITLE
Fix stale events showing upon running commands

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddTagCommand.java
@@ -92,6 +92,7 @@ public class AddTagCommand extends Command {
         applyTags(model, uniquePersons);
         // refresh the listing
         model.showAllPersonsPinnedFirst();
+        model.showNoEvents();
 
         String tagNames = tagsToAssign.stream()
                 .map(t -> t.tagName)

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -121,6 +121,7 @@ public class EditCommand extends Command {
 
         model.setPerson(personToEdit, editedPerson);
         model.showPerson(editedPerson);
+        model.showEventsForPerson(editedPerson);
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson)));
     }
 

--- a/src/main/java/seedu/address/logic/commands/PinCommand.java
+++ b/src/main/java/seedu/address/logic/commands/PinCommand.java
@@ -66,6 +66,7 @@ public class PinCommand extends Command {
 
         model.pinPerson(personToPin);
         model.showAllPersonsPinnedFirst();
+        model.showNoEvents();
         return new CommandResult(String.format(MESSAGE_PIN_PERSON_SUCCESS, Messages.format(personToPin)));
     }
 

--- a/src/main/java/seedu/address/logic/commands/UnpinCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnpinCommand.java
@@ -65,6 +65,7 @@ public class UnpinCommand extends Command {
 
         model.unpinPerson(personToUnpin);
         model.showAllPersonsPinnedFirst();
+        model.showNoEvents();
         return new CommandResult(String.format(MESSAGE_UNPIN_PERSON_SUCCESS, Messages.format(personToUnpin)));
     }
 

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -73,6 +73,7 @@ public class EditCommandTest {
                 new UserPrefs());
         expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
         expectedModel.showPerson(editedPerson);
+        expectedModel.showEventsForPerson(editedPerson);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
@@ -148,6 +149,7 @@ public class EditCommandTest {
                 new UserPrefs());
         expectedModel.setPerson(personToEdit, editedPerson);
         expectedModel.showPerson(editedPerson);
+        expectedModel.showEventsForPerson(editedPerson);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
@@ -167,6 +169,7 @@ public class EditCommandTest {
                 new UserPrefs());
         expectedModel.setPerson(personToEdit, editedPerson);
         expectedModel.showPerson(editedPerson);
+        expectedModel.showEventsForPerson(editedPerson);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
@@ -186,6 +189,7 @@ public class EditCommandTest {
                 new UserPrefs());
         expectedModel.setPerson(personToEdit, editedPerson);
         expectedModel.showPerson(editedPerson);
+        expectedModel.showEventsForPerson(editedPerson);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
@@ -261,6 +265,7 @@ public class EditCommandTest {
                 new UserPrefs());
         expectedModel.setPerson(personToEdit, editedPerson);
         expectedModel.showPerson(editedPerson);
+        expectedModel.showEventsForPerson(editedPerson);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
@@ -285,6 +290,7 @@ public class EditCommandTest {
                 new UserPrefs());
         expectedModel.setPerson(personToEdit, editedPerson);
         expectedModel.showPerson(editedPerson);
+        expectedModel.showEventsForPerson(editedPerson);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
@@ -369,6 +375,7 @@ public class EditCommandTest {
                 new UserPrefs());
         expectedModel.setPerson(targetPerson, editedPerson);
         expectedModel.showPerson(editedPerson);
+        expectedModel.showEventsForPerson(editedPerson);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }


### PR DESCRIPTION
## Summary
This PR updates the behavior of several commands to ensure that the events list is hidden whenever a person is pinned, unpinned and tagged, and updating the events list when a person is edited. 

This provides a more consistent user interface experience after these actions.

## UI Updates:
* Added a call to `model.showNoEvents()` in the `AddTagCommand`, `PinCommand` and `UnpinCommand` to hide the events list after executing those commands.

* Added a call to `model.showEventsForPerson(editedPerson)` in the `EditCommand` class to update the events list after executing the command.

Closes #401.