### PR TITLE
Fix filter command parsing logic

### DIFF
--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -45,14 +45,19 @@ public class FilterCommandParser implements Parser<FilterCommand> {
 
         if (allTags.isBlank()) {
             throw new ParseException("Error: Tag value cannot be empty.\n"
-                    + "Fix: Provide a valid tag name after 't/' (e.g. filter t/CS2103 Group)");
+                    + "Provide a valid tag name after 't/' (e.g. filter t/CS2103 Group)");
+        }
+        List<String> splitTags = Arrays.stream(allTags.split(",", -1))
+                .map(String::trim)
+                .collect(Collectors.toList());
+        boolean hasEmptyEntry = splitTags.stream().anyMatch(String::isEmpty);
+        if (hasEmptyEntry) {
+            throw new ParseException("Error: Tag value cannot be empty.\n"
+                    + "Provide a valid tag name after 't/' (e.g. filter t/CS2103 Group)");
         }
 
-        List<String> tagKeywords = Arrays.stream(allTags.split(","))
-                .map(String::trim)
-                .filter(tag -> !tag.isEmpty())
-                .collect(Collectors.toList());
-
+        // Validate tags and collect final keywords
+        List<String> tagKeywords = splitTags;
         for (String tag : tagKeywords) {
             if (!tag.matches(Tag.VALIDATION_REGEX)) {
                 throw new ParseException(Tag.MESSAGE_CONSTRAINTS);

--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -56,7 +56,6 @@ public class FilterCommandParser implements Parser<FilterCommand> {
                     + "Provide a valid tag name after 't/' (e.g. filter t/CS2103 Group)");
         }
 
-        // Validate tags and collect final keywords
         List<String> tagKeywords = splitTags;
         for (String tag : tagKeywords) {
             if (!tag.matches(Tag.VALIDATION_REGEX)) {

--- a/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
@@ -18,9 +18,16 @@ public class FilterCommandParserTest {
     private final FilterCommandParser parser = new FilterCommandParser();
 
     @Test
-    public void parse_validInputWithEmptyEntries_success() {
-        assertParseSuccess(parser, " " + PREFIX_TAG + "friends, , family ,",
+    public void parse_validInput_success() {
+        assertParseSuccess(parser, " " + PREFIX_TAG + "friends, family",
                 new FilterCommand(new TagContainsKeywordsPredicate(List.of("friends", "family"))));
+    }
+
+    @Test
+    public void parse_validInputWithEmptyEntries_failure() {
+        assertParseFailure(parser, " " + PREFIX_TAG + "friends, , family ,",
+                "Error: Tag value cannot be empty.\n"
+                        + "Provide a valid tag name after 't/' (e.g. filter t/CS2103 Group)");
     }
 
     @Test
@@ -46,7 +53,7 @@ public class FilterCommandParserTest {
     public void parse_blankTagValue_failure() {
         assertParseFailure(parser, " " + PREFIX_TAG + "   ",
                 "Error: Tag value cannot be empty.\n"
-                        + "Fix: Provide a valid tag name after 't/' (e.g. filter t/CS2103 Group)");
+                        + "Provide a valid tag name after 't/' (e.g. filter t/CS2103 Group)");
     }
 
     @Test


### PR DESCRIPTION
## Description
This PR improves the robustness of the tag parsing logic in the `FilterCommandParser` by adding stricter validation for empty tag entries and updates the corresponding tests to reflect these changes. 

The main focus is on preventing empty tag values when parsing comma-separated tags and ensuring clear error messages for users.

## Parser validation improvements
Updated `FilterCommandParser` to check for empty tag entries when splitting tags by commas, throwing a `ParseException` if any tag is empty.

## Test Case Updates
Modified test `parse_validInputWithEmptyEntries_success` to expect a failure when empty tag entries are present, and added a new test to assert this behaviour.

Updated test assertions to match the revised error message format.

Fixes #405.